### PR TITLE
R4sn4 patch1

### DIFF
--- a/src/main/scala/Engine.scala
+++ b/src/main/scala/Engine.scala
@@ -44,7 +44,8 @@ case class Query(
   num: Option[Int] = None, // default: whatever is in algorithm params, which itself has a default--probably 20
   eventNames: Option[List[String]], // names used to ID all user actions
   withRanks: Option[Boolean] = None, // Add to ItemScore rank fields values, default fasle
-  excludeFields: Option[List[excludeField]]) // blacklist fields specified in query 
+  excludeFields: Option[List[excludeField]], // blacklist fields specified in query 
+  numericRangeFilter: Option[List[RangeField]]) // numeric range filter
     extends Serializable
 
 
@@ -61,6 +62,14 @@ case class excludeField(
   name: String, // name of metadata field
   values: List[String]) // fields can have multiple values like tags of a single value as when using hierarchical
   
+/** Used to specify the numeric range for a query */
+case class RangeField(
+  name: String,
+  greaterThan: Option[Float],
+  lessThan: Option[Float],
+  greaterThanOrEqual: Option[Float],
+  lessThanOrEqual: Option[Float])
+
 /** Used to specify the date range for a query */
 case class DateRange(
   name: String, // name of item property for the date comparison

--- a/src/main/scala/Engine.scala
+++ b/src/main/scala/Engine.scala
@@ -43,7 +43,8 @@ case class Query(
   // to what is in the algorithm params or false
   num: Option[Int] = None, // default: whatever is in algorithm params, which itself has a default--probably 20
   eventNames: Option[List[String]], // names used to ID all user actions
-  withRanks: Option[Boolean] = None) // Add to ItemScore rank fields values, default fasle
+  withRanks: Option[Boolean] = None, // Add to ItemScore rank fields values, default fasle
+  excludeFields: Option[List[excludeField]]) // blacklist fields specified in query
     extends Serializable
 
 /** Used to specify how Fields are represented in engine.json */

--- a/src/main/scala/Engine.scala
+++ b/src/main/scala/Engine.scala
@@ -44,8 +44,9 @@ case class Query(
   num: Option[Int] = None, // default: whatever is in algorithm params, which itself has a default--probably 20
   eventNames: Option[List[String]], // names used to ID all user actions
   withRanks: Option[Boolean] = None, // Add to ItemScore rank fields values, default fasle
-  excludeFields: Option[List[excludeField]]) // blacklist fields specified in query
+  excludeFields: Option[List[excludeField]]) // blacklist fields specified in query 
     extends Serializable
+
 
 /** Used to specify how Fields are represented in engine.json */
 case class Field( // no optional values for fields, whne specified

--- a/src/main/scala/Engine.scala
+++ b/src/main/scala/Engine.scala
@@ -56,6 +56,11 @@ case class Field( // no optional values for fields, whne specified
   bias: Float) // any positive value is a boost, negative is a filter
     extends Serializable
 
+/** Used to specify how exclude fields are represented in engine.json */
+case class excludeField(
+  name: String, // name of metadata field
+  values: List[String]) // fields can have multiple values like tags of a single value as when using hierarchical
+  
 /** Used to specify the date range for a query */
 case class DateRange(
   name: String, // name of item property for the date comparison

--- a/src/main/scala/URAlgorithm.scala
+++ b/src/main/scala/URAlgorithm.scala
@@ -867,7 +867,194 @@ class URAlgorithm(val ap: URAlgorithmParams)
     }
     json
   }
+  
+  def getFilteringNumericRange(query: Query): Seq[JValue] = {
+    var json = Seq[JValue]()
+    if (query.numericRangeFilter.nonEmpty) {
+      val numericRanges = query.numericRangeFilter.getOrElse(List.empty)
+      numericRanges.foreach { numericRange =>
+        val name = numericRange.name
+        if (numericRange.greaterThan.nonEmpty && numericRange.lessThan.nonEmpty) {
+          // val name = numericRange.name
+          val greaterThan = numericRange.greaterThan.get
+          val lessThan = numericRange.lessThan.get
+          val range =
+            s"""
+                 |{
+                 |  "constant_score": {
+                 |    "filter": {
+                 |      "range": {
+                 |        "$name": {
+                 |           "gt": $greaterThan,
+                 |           "lt": $lessThan
+                 |           }
+                 |         }
+                 |       },
+                 |      "boost": 0
+                 |   }
+                 |}
+              """.stripMargin
+          json = json :+ parse(range)
+        } else if (numericRange.greaterThan.nonEmpty && numericRange.lessThanOrEqual.nonEmpty) {
+          //val name = numericRange.name
+          val greaterThan = numericRange.greaterThan.get
+          val lessThanOrEqual = numericRange.lessThanOrEqual.get
+          val range =
+            s"""
+                 |{
+                 |  "constant_score": {
+                 |      "filter": {
+                 |        "range": {
+                 |          "$name": {
+                 |            "gt": $greaterThan,
+                 |            "lte": $lessThanOrEqual
+                 |            }
+                 |         }
+                 |       },
+                 |       "boost": 0
+                 |    }
+                 |}
+              """.stripMargin
+          json = json :+ parse(range)
+        } else if (numericRange.greaterThanOrEqual.nonEmpty && numericRange.lessThan.nonEmpty) {
+          //val name = numericRange.name
+          val greaterThanOrEqual = numericRange.greaterThanOrEqual.get
+          val lessThan = numericRange.lessThan.get
+          val range =
+            s"""
+                 |{
+                 |  "constant_score": {
+                 |    "filter": {
+                 |      "range": {
+                 |        "$name": {
+                 |          "gte": $greaterThanOrEqual,
+                 |          "lt": $lessThan
+                 |          }
+                 |        }
+                 |      },
+                 |      "boost": 0
+                 |    }
+                 |}
+              """.stripMargin
+          json = json :+ parse(range)
+        } else if (numericRange.greaterThanOrEqual.nonEmpty && numericRange.lessThanOrEqual.nonEmpty) {
+          //val name = numericRange.name
+          val greaterThanOrEqual = numericRange.greaterThanOrEqual.get
+          val lessThanOrEqual = numericRange.lessThanOrEqual.get
+          val range =
+            s"""
+                 |{
+                 |  "constant_score": {
+                 |    "filter": {
+                 |      "range": {
+                 |        "$name": {
+                 |          "gte": $greaterThanOrEqual,
+                 |          "lte": $lessThanOrEqual
+                 |        }
+                 |      }
+                 |    },
+                 |    "boost": 0
+                 |  }
+                 |}
+            """.stripMargin
 
+          json = json :+ parse(range)
+
+        } else if (numericRange.greaterThan.nonEmpty) {
+          //val name = numericRange.name
+          val greaterThan = numericRange.greaterThan.get
+          val range =
+            s"""
+                 |{
+                 |  "constant_score": {
+                 |    "filter": {
+                 |      "range": {
+                 |        "$name": {
+                 |          "gt": $greaterThan
+                 |        }
+                 |      }
+                 |    },
+                 |    "boost": 0
+                 |  }
+                 |}
+        """.stripMargin
+
+          json = json :+ parse(range)
+
+        } else if (numericRange.greaterThanOrEqual.nonEmpty) {
+          //val name = numericRange.name
+          val greaterThanOrEqual = numericRange.greaterThanOrEqual.get
+          val range =
+            s"""
+                 |{
+                 |  "constant_score": {
+                 |    "filter": {
+                 |      "range": {
+                 |        "$name": {
+                 |          "gte": $greaterThanOrEqual
+                 |        }
+                 |      }
+                 |    },
+                 |    "boost": 0
+                 |  }
+                 |}
+            """.stripMargin
+
+          json = json :+ parse(range)
+
+        } else if (numericRange.lessThan.nonEmpty) {
+          //val name = numericRange.name
+          val lessThan = numericRange.lessThan.get
+          val range =
+            s"""
+                 |{
+                 |  "constant_score": {
+                 |    "filter": {
+                 |      "range": {
+                 |        "$name": {
+                 |          "lt": $lessThan
+                 |        }
+                 |      }
+                 |    },
+                 |    "boost": 0
+                 |  }
+                 |}
+            """.stripMargin
+
+          json = json :+ parse(range)
+
+        } else if (numericRange.lessThanOrEqual.nonEmpty) {
+          //val name = numericRange.name
+          val lessThanOrEqual = numericRange.lessThanOrEqual.get
+          val range =
+            s"""
+                 |{
+                 |  "constant_score": {
+                 |    "filter": {
+                 |      "range": {
+                 |        "$name": {
+                 |          "lte": $lessThanOrEqual
+                 |        }
+                 |      }
+                 |    },
+                 |    "boost": 0
+                 |  }
+                 |}
+              """.stripMargin
+
+          json = json :+ parse(range)
+
+        } else {
+          logger.info(
+            """
+                |Misconfigured range information, your query's numeric Range is incorrect.
+                |Ingoring  range information for this query.""".stripMargin)
+          Seq.empty
+        }
+      }
+    }
+    json
+  }
   def getRankingMapping: Map[String, String] = rankingFieldNames map { fieldName =>
     fieldName -> "float"
   } toMap

--- a/src/main/scala/URAlgorithm.scala
+++ b/src/main/scala/URAlgorithm.scala
@@ -616,13 +616,14 @@ class URAlgorithm(val ap: URAlgorithmParams)
 
     val filteringMetadata = getFilteringMetadata(query)
     val filteringDateRange = getFilteringDateRange(query)
+    val filteringNumericRange = getFilteringNumericRange(query)
     val allFilteringCorrelators = recentUserHistoryFilter ++ similarItemsFilter ++ filteringMetadata
 
     val mustFields: Seq[JValue] = allFilteringCorrelators.map {
       case FilterCorrelators(actionName, itemIDs) =>
         render("terms" -> (actionName -> itemIDs) ~ ("boost" -> 0))
     }
-    mustFields ++ filteringDateRange
+    mustFields ++ filteringDateRange ++ filteringNumericRange
   }
 
   /** Build not must query part */

--- a/src/main/scala/URAlgorithm.scala
+++ b/src/main/scala/URAlgorithm.scala
@@ -876,7 +876,6 @@ class URAlgorithm(val ap: URAlgorithmParams)
       numericRanges.foreach { numericRange =>
         val name = numericRange.name
         if (numericRange.greaterThan.nonEmpty && numericRange.lessThan.nonEmpty) {
-          // val name = numericRange.name
           val greaterThan = numericRange.greaterThan.get
           val lessThan = numericRange.lessThan.get
           val range =
@@ -897,7 +896,6 @@ class URAlgorithm(val ap: URAlgorithmParams)
               """.stripMargin
           json = json :+ parse(range)
         } else if (numericRange.greaterThan.nonEmpty && numericRange.lessThanOrEqual.nonEmpty) {
-          //val name = numericRange.name
           val greaterThan = numericRange.greaterThan.get
           val lessThanOrEqual = numericRange.lessThanOrEqual.get
           val range =
@@ -918,7 +916,6 @@ class URAlgorithm(val ap: URAlgorithmParams)
               """.stripMargin
           json = json :+ parse(range)
         } else if (numericRange.greaterThanOrEqual.nonEmpty && numericRange.lessThan.nonEmpty) {
-          //val name = numericRange.name
           val greaterThanOrEqual = numericRange.greaterThanOrEqual.get
           val lessThan = numericRange.lessThan.get
           val range =
@@ -939,7 +936,6 @@ class URAlgorithm(val ap: URAlgorithmParams)
               """.stripMargin
           json = json :+ parse(range)
         } else if (numericRange.greaterThanOrEqual.nonEmpty && numericRange.lessThanOrEqual.nonEmpty) {
-          //val name = numericRange.name
           val greaterThanOrEqual = numericRange.greaterThanOrEqual.get
           val lessThanOrEqual = numericRange.lessThanOrEqual.get
           val range =
@@ -962,7 +958,6 @@ class URAlgorithm(val ap: URAlgorithmParams)
           json = json :+ parse(range)
 
         } else if (numericRange.greaterThan.nonEmpty) {
-          //val name = numericRange.name
           val greaterThan = numericRange.greaterThan.get
           val range =
             s"""
@@ -983,7 +978,6 @@ class URAlgorithm(val ap: URAlgorithmParams)
           json = json :+ parse(range)
 
         } else if (numericRange.greaterThanOrEqual.nonEmpty) {
-          //val name = numericRange.name
           val greaterThanOrEqual = numericRange.greaterThanOrEqual.get
           val range =
             s"""
@@ -1004,7 +998,6 @@ class URAlgorithm(val ap: URAlgorithmParams)
           json = json :+ parse(range)
 
         } else if (numericRange.lessThan.nonEmpty) {
-          //val name = numericRange.name
           val lessThan = numericRange.lessThan.get
           val range =
             s"""
@@ -1025,7 +1018,6 @@ class URAlgorithm(val ap: URAlgorithmParams)
           json = json :+ parse(range)
 
         } else if (numericRange.lessThanOrEqual.nonEmpty) {
-          //val name = numericRange.name
           val lessThanOrEqual = numericRange.lessThanOrEqual.get
           val range =
             s"""


### PR DESCRIPTION
Generalized numeric Range filter -

Following filter limits can be specified -  

1. greaterThan = i, lessThan = j
2. greaterThan = i,  lessThanOrEqual = j
3. greaterThanOrEqual = i, lessThanOrEqual = j
4. greaterThanOrEqual = i, lessThan = j
5. greatherThan = i
6. lessThan = i
7. greaterThanOrEqual = i
8. lessThanOrEqual = i


Filter range is specified in query like this - 

curl -H "Content-Type:application/json" -d '{"item": "i1", "numericRangeFilter": [{"name":"price", "greaterThan":20, "lessThanOrOrEqual":90},{"name":"popRank, "greaterThan":2, "lessThan":19}]}' http://localhost:8000/queries.json






