### PR TITLE
Fix paramsBoostedFields and paramsFilterFields

### DIFF
--- a/src/main/scala/URAlgorithm.scala
+++ b/src/main/scala/URAlgorithm.scala
@@ -738,7 +738,7 @@ class URAlgorithm(val ap: URAlgorithmParams)
 
   /** get all metadata fields that potentially have boosts (not filters) */
   def getBoostedMetadata(query: Query): Seq[BoostableCorrelators] = {
-    val paramsBoostedFields = fields.filter(_.bias < 0f)
+    val paramsBoostedFields = fields.filter(_.bias >= 0f)
     val queryBoostedFields = query.fields.getOrEmpty.filter(_.bias >= 0f)
 
     (queryBoostedFields ++ paramsBoostedFields)
@@ -748,7 +748,7 @@ class URAlgorithm(val ap: URAlgorithmParams)
 
   /** get all metadata fields that are filters (not boosts) */
   def getFilteringMetadata(query: Query): Seq[FilterCorrelators] = {
-    val paramsFilterFields = fields.filter(_.bias >= 0f)
+    val paramsFilterFields = fields.filter(_.bias < 0f)
     val queryFilterFields = query.fields.getOrEmpty.filter(_.bias < 0f)
 
     (queryFilterFields ++ paramsFilterFields)


### PR DESCRIPTION
**Description**:
According to documentation: http://actionml.com/docs/ur_config
**fields**: optional, default = none. An array of ... . **Positive biases are boosts** any negative number will filter out any results that do not contain the values in the field name.

**Problem**:
When adding fields to algorithm parameters with a negative bias (-1) they will not be filtered, but instead added as boosted fields with a negative value. Providing a positive number will cause this to be a filter.

If you look at the annotations, someone has tried to fix this but instead of swapping the ">" and "<", he moved "=" instead.

**Solution**:
I have corrected this issue so that paramsFields are consistent with queryFields. (see queryBoostedFields below)