### PR TITLE
Added pagination support

### DIFF
--- a/src/main/scala/Engine.scala
+++ b/src/main/scala/Engine.scala
@@ -42,6 +42,7 @@ case class Query(
   returnSelf: Option[Boolean] = None, // means for an item query should the item itself be returned, defaults
   // to what is in the algorithm params or false
   num: Option[Int] = None, // default: whatever is in algorithm params, which itself has a default--probably 20
+  offset: Option[Int] = 0, // Used for pagination, default: 0
   eventNames: Option[List[String]], // names used to ID all user actions
   withRanks: Option[Boolean] = None) // Add to ItemScore rank fields values, default fasle
     extends Serializable

--- a/src/main/scala/URAlgorithm.scala
+++ b/src/main/scala/URAlgorithm.scala
@@ -368,7 +368,8 @@ class URAlgorithm(val ap: URAlgorithmParams)
   /** Return a list of items recommended for a user identified in the query
    *  The ES json query looks like this:
    *  {
-   *    "size": 20
+   *    "size": 20,
+   *    "from": 0,
    *    "query": {
    *      "bool": {
    *        "should": [
@@ -396,14 +397,16 @@ class URAlgorithm(val ap: URAlgorithmParams)
    *              "category": ["cat1"],
    *              "boost": 0
    *            }
-   *          },
-   *         {
-   *        "must_not": [//blacklisted items
+   *          }
+   *        ],
+   *        "must_not": [ //blacklisted items
    *          {
    *            "ids": {
    *              "values": ["items-id1", "item-id2", ...]
    *            }
-   *          },
+   *          }
+   *        ]
+   *      },
    *         {
    *           "constant_score": {// date in query must fall between the expire and available dates of an item
    *             "filter": {
@@ -529,6 +532,7 @@ class URAlgorithm(val ap: URAlgorithmParams)
       // purchase or view, we'll pass both to the query if the user history or items correlators are empty
       // then metadata or backfill must be relied on to return results.
       val numRecs = query.num.getOrElse(limit)
+      val offset = query.offset.getOrElse(0)
       val should = buildQueryShould(query, boostable)
       val must = buildQueryMust(query, boostable)
       val mustNot = buildQueryMustNot(query, events)
@@ -536,6 +540,7 @@ class URAlgorithm(val ap: URAlgorithmParams)
 
       val json =
         ("size" -> numRecs) ~
+        ("from" -> offset) ~
           ("query" ->
             ("bool" ->
               ("should" -> should) ~


### PR DESCRIPTION
Added offset parameter to Query class.
Get next page results by increasing offset by any multiplier of num parameter.

Take the offset parameter from Query and use it as from in the Elasticsearch query.
@see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html

Updated predict function documentation.
Added from parameter to ES json query example and added missing brackets.